### PR TITLE
Associate data with the right TextEditor

### DIFF
--- a/lib/import-cost-atom-view.js
+++ b/lib/import-cost-atom-view.js
@@ -21,15 +21,11 @@ export default class ImportCostAtomView {
       if (!event.isValid) {
         this.destroy();
       } else {
-        this.updatePosition(
-          editor.getLineHeightInPixels(),
-          this.marker.getStartBufferPosition().column);
+        this.updatePosition(editor);
       }
     });
 
-    const lineHeight = editor.getLineHeightInPixels();
-    const lineLength = editor.getBuffer().lineLengthForRow(row);
-    this.updatePosition(lineHeight, lineLength);
+    this.updatePosition(editor);
 
     editor.decorateMarker(this.marker, {
       type: 'block',
@@ -38,7 +34,9 @@ export default class ImportCostAtomView {
     });
   }
 
-  updatePosition(height, length) {
+  updatePosition(editor) {
+    const height = editor.getLineHeightInPixels();
+    const length = this.marker.getStartBufferPosition().column;
     const inlineStyle = `margin: -${height}px 0 0 ${length + 2}ch`;
     this.element.firstChild.setAttribute('style', inlineStyle);
   }

--- a/lib/import-cost-atom-view.js
+++ b/lib/import-cost-atom-view.js
@@ -1,6 +1,7 @@
 'use babel';
 
-import { CompositeDisposable, Point } from 'atom'; // eslint-disable-line
+// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
+import { CompositeDisposable } from 'atom';
 import filesize from 'filesize';
 
 export default class ImportCostAtomView {
@@ -16,13 +17,12 @@ export default class ImportCostAtomView {
       invalidate: 'touch',
     });
 
-    this.disposer = this.marker.onDidChange((event) => {
-      if (!event.isValid) {
-        this.destroy();
-      } else {
+    this.subscriptions = new CompositeDisposable();
+    this.subscriptions.add(this.marker.onDidChange((event) => {
+      if (event.isValid) {
         this.updatePosition(editor);
       }
-    });
+    }));
 
     this.updatePosition(editor);
 
@@ -50,7 +50,7 @@ export default class ImportCostAtomView {
   }
 
   destroy() {
-    this.disposer.dispose();
+    this.subscriptions.dispose();
     this.marker.destroy();
   }
 }

--- a/lib/import-cost-atom-view.js
+++ b/lib/import-cost-atom-view.js
@@ -4,7 +4,7 @@ import { CompositeDisposable, Point } from 'atom'; // eslint-disable-line
 import filesize from 'filesize';
 
 export default class ImportCostAtomView {
-  constructor(line) {
+  constructor(editor, line) {
     this.element = document.createElement('div');
     this.element.appendChild(document.createElement('span'));
     this.element.classList.add('import-cost-atom', 'loading');
@@ -12,7 +12,6 @@ export default class ImportCostAtomView {
 
     const row = line - 1;
 
-    const editor = atom.workspace.getActiveTextEditor();
     this.marker = editor.markBufferPosition([row, Infinity], {
       invalidate: 'touch',
     });

--- a/lib/import-cost-atom.js
+++ b/lib/import-cost-atom.js
@@ -27,7 +27,6 @@ export default {
 
     this.calculateCost = this.calculateCost.bind(this);
 
-    atom.workspace.onDidChangeActivePaneItem(() => this.calculateCost());
     // Observe all TextEditors to calculate the costs
     this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
       // Save the subscriptions associated with the editor in a set
@@ -40,6 +39,10 @@ export default {
       this.calculateCost(editor);
     }));
 
+    // Watch for active item changes to update screen position measurements
+    // when the user switches to a TextEditor that was inactive
+    this.subscriptions.add(atom.workspace.onDidStopChangingActivePaneItem(
+      editor => this.updatePositions(editor)));
   },
 
   calculateCost(editor) {
@@ -81,8 +84,15 @@ export default {
     });
   },
 
+  updatePositions(editor) {
+    if (!atom.workspace.isTextEditor(editor)) {
+      return;
     }
 
+    if (this.editors.has(editor)) {
+      this.editors.get(editor).packages.forEach(view => view.updatePosition(editor));
+    }
+  },
 
   cleanupEditorImportCosts(editorData) {
     // Remove the old importCost instance

--- a/lib/import-cost-atom.js
+++ b/lib/import-cost-atom.js
@@ -1,5 +1,7 @@
 'use babel';
 
+// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
+import { CompositeDisposable } from 'atom';
 import { importCost, cleanup, JAVASCRIPT, TYPESCRIPT } from 'import-cost';
 import ImportCostAtomView from './import-cost-atom-view';
 
@@ -16,28 +18,32 @@ function getFileLanguage(path) {
 }
 
 export default {
-  importCostLabels: null,
-  importCostEmitters: null,
+  editors: null,
+  subscriptions: null,
 
   activate() {
-    this.importCostLabels = new Map();
-    this.importCostEmitters = new Map();
+    this.editors = new Map();
+    this.subscriptions = new CompositeDisposable();
 
-    this.renderCost = this.renderCost.bind(this);
     this.calculateCost = this.calculateCost.bind(this);
 
     atom.workspace.onDidChangeActivePaneItem(() => this.calculateCost());
-    atom.workspace.observeTextEditors((editor) => {
-      editor.onDidSave(() => this.calculateCost());
-    });
+    // Observe all TextEditors to calculate the costs
+    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      // Save the subscriptions associated with the editor in a set
+      const editorSubs = new Set();
+      editorSubs.add(editor.onDidSave(() => this.calculateCost(editor)));
+      editorSubs.add(editor.onDidDestroy(() => this.cleanupEditor(editor)));
+      // Save to the map of editors
+      this.editors.set(editor, { subscriptions: editorSubs });
+      // Run the initial cost calculation on the new TextEditor
+      this.calculateCost(editor);
+    }));
 
-    this.calculateCost();
   },
 
-  calculateCost() {
-    const editor = atom.workspace.getActiveTextEditor();
-
-    if (!editor) {
+  calculateCost(editor) {
+    if (!atom.workspace.isTextEditor(editor)) {
       return;
     }
 
@@ -48,41 +54,64 @@ export default {
       return;
     }
 
+    const editorData = this.editors.get(editor);
+
     const content = editor.getText();
 
-    if (this.importCostEmitters.has(path)) {
-      const emitter = this.importCostEmitters.get(path);
-      emitter.removeAllListeners();
+    if (editorData.importCosts) {
+      this.cleanupEditorImportCosts(editorData);
     }
 
-    this.importCostEmitters.set(path, importCost(path, content, language));
-    this.importCostEmitters.get(path).on('start', (packages) => {
+    editorData.importCosts = importCost(path, content, language);
+
+    // eslint-disable-next-line no-console
+    editorData.importCosts.on('error', console.error);
+
+    editorData.importCosts.on('start', (packages) => {
+      editorData.packages = new Map();
+      // List of imports has been determined, mark as calculating
       packages.forEach((pkg) => {
-        this.renderCost(path, pkg);
+        editorData.packages.set(pkg.line, new ImportCostAtomView(editor, pkg.line));
       });
     });
-    this.importCostEmitters.get(path).on('calculated', (pkg) => {
-      this.importCostLabels.get(pkg.line).updateText(pkg);
-    });
 
-    this.importCostEmitters.get(path).on('error', console.error);
+    editorData.importCosts.on('calculated', (pkg) => {
+      // A package's size has been calculated
+      editorData.packages.get(pkg.line).updateText(pkg);
+    });
   },
 
-  renderCost(path, pkg) {
-    if (this.importCostLabels.has(pkg.line)) {
-      this.importCostLabels.get(pkg.line).destroy();
     }
 
-    this.importCostLabels.set(pkg.line, new ImportCostAtomView(pkg.line));
+
+  cleanupEditorImportCosts(editorData) {
+    // Remove the old importCost instance
+    editorData.importCosts.removeAllListeners();
+    // Cleanup any existing package displays
+    editorData.packages.forEach(view => view.destroy());
+    editorData.packages.clear();
+  },
+
+  cleanupEditor(editor) {
+    if (this.editors.has(editor)) {
+      // When the TextEditor is destroyed remove the associated subscriptions
+      const editorData = this.editors.get(editor);
+      this.cleanupEditorImportCosts(editorData);
+      editorData.subscriptions.forEach(sub => sub.dispose());
+      editorData.subscriptions.clear();
+      this.editors.delete(editor);
+    }
   },
 
   deactivate() {
+    // Cleanup UI and TextEditor specific subscriptions
+    this.editors.forEach((data, editor) => this.cleanupEditor(editor));
+    this.editors.clear();
+
+    // Cleanup subscriptions
+    this.subscriptions.dispose();
+
     // Cleanup import-cost
     cleanup();
-
-    // Cleanup UI
-    [].concat([...this.importCostLabels.values()]).forEach(label => label.destroy());
-    this.importCostLabels.clear();
-    this.importCostEmitters.clear();
   },
 };

--- a/lib/import-cost-atom.js
+++ b/lib/import-cost-atom.js
@@ -82,6 +82,17 @@ export default {
       // A package's size has been calculated
       editorData.packages.get(pkg.line).updateText(pkg);
     });
+
+    editorData.importCosts.on('done', (packages) => {
+      // All packages that can be calculated are done, remove ones that couldn't
+      // be calculated.
+      editorData.packages.forEach((view, line) => {
+        if (!packages.some(pkg => pkg.line === line)) {
+          view.destroy();
+          editorData.packages.delete(line);
+        }
+      });
+    });
   },
 
   updatePositions(editor) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "import-cost-atom",
-  "version": "0.1.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1420,15 +1420,6 @@
         "eslint-restricted-globals": "0.1.1"
       }
     },
-    "eslint-config-prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.3.0.tgz",
-      "integrity": "sha1-t1seq+oMi5ezRANkfuJds0m52KA=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "5.0.1"
-      }
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
@@ -1764,12 +1755,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-    },
-    "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -3918,14 +3903,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3953,6 +3930,14 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/styles/import-cost-atom.less
+++ b/styles/import-cost-atom.less
@@ -7,6 +7,7 @@
 .import-cost-atom {
   opacity: 0.4;
   display: flex;
+  pointer-events: none;
 
   &.loading {
     font-style: italic;


### PR DESCRIPTION
Make data associated with a specific `TextEditor`.

This primarily fixes two major bugs with the previous implementation:
* When Atom first started up, a request was sent off to calculate the sizes for all active `TextEditor`s, but the function used only worked on the currently active `TextEditor`. Modify this so that all data is associated with the proper `TextEditor`.

* When `import-cost` finished calculating the size of an import, the marker would be created on the correct line... but potentially the wrong `TextEditor` if the user had switched editors between when the request was initialized and when it was resolved.

Additionally:
* Make decorations click-through so clicking where they are changes the cursor line instead of doing nothing.
* Don't attempt to destroy the `Marker` in `onDidChange`: Although this is _correct_, it seems to be triggering an internal bug in Atom that I'm not sure whether is a misunderstanding on how to use `Markers` or a real bug in Atom. In either case, leaving the invalid `Marker` around till it can be destroyed when the `import-cost` results are updated shouldn't pose an issue.
* Handle the `done` even from `import-cost`. Although this shouldn't make a difference in almost every case, it's better to handle it than not.

This ended up being a larger change than I was thinking, feel free to use as much or as little of this as you would like @IanMitchell!

Fixes #5.